### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/DLL/Process.cpp
+++ b/DLL/Process.cpp
@@ -127,10 +127,10 @@ SECTION_INFO Process::GetModuleSection(string p_sModule, string p_sSection)
 			memcpy(&ntHeaders, (void *)((ADDRESS_VALUE)hModule + dos.e_lfanew), sizeof(IMAGE_NT_HEADERS));
 
 			// Get sections
-
-			pSections = new IMAGE_SECTION_HEADER[ntHeaders.FileHeader.NumberOfSections];
-
-			if(pSections == NULL)
+			try {
+				pSections = new IMAGE_SECTION_HEADER[ntHeaders.FileHeader.NumberOfSections];
+			}
+			catch (std::bad_alloc& ba)
 			{
 				DebugLog::LogInt("[ERROR] Cannot allocate space for sections: ", ntHeaders.FileHeader.NumberOfSections);
 				return oSectionData;
@@ -149,7 +149,7 @@ SECTION_INFO Process::GetModuleSection(string p_sModule, string p_sSection)
 				{
 					oSectionData.dwSize = pSections[j].SizeOfRawData;
 					oSectionData.dwStartAddress = (ADDRESS_VALUE)hModule +  pSections[j].VirtualAddress;
-
+					delete pSections;
 					return oSectionData;
 				}
 			}
@@ -157,7 +157,7 @@ SECTION_INFO Process::GetModuleSection(string p_sModule, string p_sSection)
 	}
 
 	DebugLog::LogString("[ERROR] GetModuleSection did not find the section: ", p_sSection);
-
+	delete pSections;
 	return oSectionData;
 }
 

--- a/DLL/ReflectiveLoader.cpp
+++ b/DLL/ReflectiveLoader.cpp
@@ -239,8 +239,7 @@ DLLEXPORT ULONG_PTR WINAPI ReflectiveLoader( VOID )
 					uiAddressArray += ( DEREF_16( uiNameOrdinals ) * sizeof(DWORD) );
 
 					// store this functions VA
-					if( dwHashValue == NTFLUSHINSTRUCTIONCACHE_HASH )
-						pNtFlushInstructionCache = (NTFLUSHINSTRUCTIONCACHE)( uiBaseAddress + DEREF_32( uiAddressArray ) );
+					pNtFlushInstructionCache = (NTFLUSHINSTRUCTIONCACHE)( uiBaseAddress + DEREF_32( uiAddressArray ) );
 
 					// decrement our counter
 					usCounter--;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings: 
[V547](https://www.viva64.com/en/w/v547/) Expression 'dwHashValue == 0x534C0AB8' is always true. reflectiveloader.cpp 242
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'pSections' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. process.cpp 133
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'pSections' pointer. A memory leak is possible. process.cpp 153